### PR TITLE
Adding country (so that the right flag will appear)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: bootcamp
 root: .
 venue: ISI, University of Southern California 
+country: United-States
 address: Davidson Continuing Education Conference Center, 3415 S Figueroa St., Los Angeles
 humandate: September 16-17, 2013
 humantime: 8:30 am - 4:30 pm


### PR DESCRIPTION
There's a new field 'country' in the YAML header that we use to add flags to the bootcamp list.
