### PR TITLE
Fixing lat/long and registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,20 @@ humandate: September 16-17, 2013
 humantime: 8:30 am - 4:30 pm
 startdate: 2013-09-16
 enddate: 2013-09-17
-latlng: 34.020493, 118.281233
-registration: restricted, use the <a href="http://usc-softwarecarpentry.eventbrite.ca/">Eventbrite site</a> for registration.
+latlng: 34.020493, -118.281233
+registration: restricted
 instructor: ["Ariel Rokem", "Matt Terry"]
 contact: admin@software-carpentry.org
 ---
 {% include bootcamps/instructors.html %}
 {% include bootcamps/what.html %}
 {% include bootcamps/who.html %}
+
+<p>
+  Enrolment in this bootcamp is restricted to FIXME.
+  Please use our <a href="http://usc-softwarecarpentry.eventbrite.ca/">Eventbrite site</a> for registration.
+</p>
+
 {% include bootcamps/requirements.html %}
 {% include bootcamps/python.html %}
 {% include bootcamps/contact.html %}


### PR DESCRIPTION
1. Longitude was in China, not California.
2. 'registration' in the header is an enumeration (the values are used to choose pin colors for our map).  I've moved a note about registration into the main page, but don't know who enrolment is restricted to --- please let me know and I'll change the FIXME, or merge and change yourself?
